### PR TITLE
RegisterPage(focus, completeMessage)

### DIFF
--- a/lib/common/auth_text_input_widget.dart
+++ b/lib/common/auth_text_input_widget.dart
@@ -14,6 +14,7 @@ class AuthTextInputWidget extends StatelessWidget {
   final Function(String) onChanged;
   final VoidCallback onEditingComplete;
   final bool isEmailValid;
+  final FocusNode? focusNode;
 
   const AuthTextInputWidget({
     super.key,
@@ -27,6 +28,7 @@ class AuthTextInputWidget extends StatelessWidget {
     required this.onChanged,
     required this.onEditingComplete,
     required this.isEmailValid,
+    this.focusNode,
   });
 
   @override
@@ -63,6 +65,7 @@ class AuthTextInputWidget extends StatelessWidget {
               children: [
                 Expanded(
                   child: TextField(
+                    focusNode: focusNode,
                     autofocus: true,
                     onEditingComplete: onEditingComplete,
                     textInputAction: TextInputAction.next,

--- a/lib/page/register_page.dart
+++ b/lib/page/register_page.dart
@@ -33,11 +33,16 @@ class _RegisterPageState extends State<RegisterPage> {
   bool showConfirmPasswordInput = false;
   bool showFinalPassword = false;
 
+  FocusNode passwordFocusNode = FocusNode();
+  FocusNode confirmPasswordFocusNode = FocusNode();
+
   @override
   void dispose() {
     emailController.dispose();
     passwordController.dispose();
     confirmPasswordController.dispose();
+    passwordFocusNode.dispose();
+    confirmPasswordFocusNode.dispose();
     super.dispose();
   }
 
@@ -53,7 +58,7 @@ class _RegisterPageState extends State<RegisterPage> {
         emailError = null;
         showPasswordInput = true;
       });
-      FocusScope.of(context).nextFocus();
+      FocusScope.of(context).requestFocus(passwordFocusNode);
     }
   }
 
@@ -69,7 +74,7 @@ class _RegisterPageState extends State<RegisterPage> {
         passwordError = null;
         showConfirmPasswordInput = true;
       });
-      FocusScope.of(context).nextFocus();
+      FocusScope.of(context).requestFocus(confirmPasswordFocusNode);
     }
   }
 
@@ -85,7 +90,6 @@ class _RegisterPageState extends State<RegisterPage> {
         confirmPasswordError = null;
         showPasswordCheckInput = true;
       });
-      FocusScope.of(context).nextFocus();
       navigateToMainPage();
     }
   }
@@ -160,6 +164,7 @@ class _RegisterPageState extends State<RegisterPage> {
                   ),
                   if (showPasswordInput)
                     AuthTextInputWidget(
+                      focusNode: passwordFocusNode,
                       obscureText: true,
                       textStyle: AppTextStyle.body120M
                           .copyWith(color: AppColor.textPrimary),
@@ -193,6 +198,7 @@ class _RegisterPageState extends State<RegisterPage> {
                   ),
                   if (showConfirmPasswordInput)
                     AuthTextInputWidget(
+                      focusNode: confirmPasswordFocusNode,
                       obscureText: true,
                       textStyle: AppTextStyle.body120M
                           .copyWith(color: AppColor.textPrimary),
@@ -201,12 +207,22 @@ class _RegisterPageState extends State<RegisterPage> {
                       controller: confirmPasswordController,
                       onClearPressed: () => confirmPasswordController.clear(),
                       keyboardType: TextInputType.text,
-                      onChanged: (String value) {},
+                      onChanged: (String value) {
+                        if (value == passwordController.text) {
+                          setState(() {
+                            showFinalPassword = true;
+                          });
+                        } else {
+                          setState(() {
+                            showFinalPassword = false;
+                          });
+                        }
+                      },
                       onEditingComplete: updateConfirmPasswordStatus,
-                      isEmailValid: showFinalPassword,
+                      isEmailValid: false,
                     ),
                   const SizedBox(height: 8),
-                  if (confirmPasswordError != null)
+                  if (confirmPasswordError != null && !showFinalPassword)
                     Text(
                       confirmPasswordError!,
                       style: AppTextStyle.caption213R
@@ -214,16 +230,14 @@ class _RegisterPageState extends State<RegisterPage> {
                     ),
                   if (confirmPasswordError == null &&
                       showConfirmPasswordInput &&
-                      !showPasswordCheckInput)
+                      !showPasswordCheckInput &&
+                      !showFinalPassword)
                     Text(
                       AppTextList.passwordRequirementsText,
                       style: AppTextStyle.caption213R
                           .copyWith(color: AppColor.textHint),
                     ),
-                  if (passwordController.text ==
-                          confirmPasswordController.text &&
-                      confirmPasswordError == null &&
-                      confirmPasswordController.text.isNotEmpty)
+                  if (showFinalPassword)
                     Text(
                       AppTextList.passwordConfirmationSuccessText,
                       style: AppTextStyle.caption213R


### PR DESCRIPTION
RegisterPage에서 
focus를 이동시키는 것과 버튼의 클릭 효과를 없애는 것, 
비밀번호 확인 textField에서 mainPage가기 전 비밀번호 확인 완료! 메세지를 보이는 것 까지 작업하였습니다.
- 아직 다음 textField로 이동하면서 키보드가 자동으로 활성화되는 것은 구현하지 못했습니다. 비밀번호 찾기 페이지 작업이 덜 되어 그 작업부터 하고 다시 작업 하려고 합니다.
- 구현 영상입니다. https://imgur.com/Vsu6vQp